### PR TITLE
Fix Prim's algorithm implementation and update tests

### DIFF
--- a/src/AI-Algorithms-Graph-Tests/AIPrimTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIPrimTest.class.st
@@ -19,7 +19,7 @@ AIPrimTest >> setUp [
 { #category : 'tests' }
 AIPrimTest >> testMinSpanningTreeComplex2 [
 
-	| tree graphType graph |
+	| resultEdges graphType graph |
 	graphType := AICyclicWeightedComplexFixture new.
 	graph :=graphType complexWeightedGraph4.
 	prim nodes: graph nodes.
@@ -29,17 +29,17 @@ AIPrimTest >> testMinSpanningTreeComplex2 [
 		to: #second
 		weight: #third.
 	prim run.
-	tree := prim reconstructMST collect: [ :e | e asTuple ].
-	self assert: tree size equals: 11.
+	resultEdges := prim minimumSpanningTreeEdges collect: [ :e | e asTuple ].
+	self assert: resultEdges size equals: 11.
 	self
-		assert: (tree inject: 0 into: [ :sum :edge | sum + edge third ])
+		assert: (resultEdges inject: 0 into: [ :sum :edge | sum + edge third ])
 		equals: 112
 ]
 
 { #category : 'tests' }
 AIPrimTest >> testMinimumSpanningTreeComplex [
 
-	| tree expectedEdges graphType graph |
+	| resultEdges expectedEdges graphType graph |
 	graphType := AICyclicWeightedComplexFixture new.
 	graph :=graphType complexWeightedGraph3.
 	prim nodes: graph nodes.
@@ -49,20 +49,20 @@ AIPrimTest >> testMinimumSpanningTreeComplex [
 		to: #second
 		weight: #third.
 	prim run.
-	tree := prim reconstructMST collect: [ :e | e asTuple ].
+	resultEdges := prim minimumSpanningTreeEdges collect: [ :e | e asTuple ].
 
 	expectedEdges := #( #( $a $d 1 ) #( $d $e 1 ) #( $d $b 2 )
 	                    #( $e $c 5 ) ).
-	self assertCollection: tree hasSameElements: expectedEdges.
+	self assertCollection: resultEdges hasSameElements: expectedEdges.
 	self
-		assert: (tree inject: 0 into: [ :sum :edge | sum + edge third ])
+		assert: (resultEdges inject: 0 into: [ :sum :edge | sum + edge third ])
 		equals: 9
 ]
 
 { #category : 'tests' }
 AIPrimTest >> testMinimumSpanningTreeSimple [
 
-	| tree expectedEdges graphType graph |
+	| resultEdges expectedEdges graphType graph |
 	graphType := AICyclicWeightedSimpleFixture new.
 	graph :=graphType simpleWeightedGraph2.
 	prim nodes: graph nodes.
@@ -72,11 +72,11 @@ AIPrimTest >> testMinimumSpanningTreeSimple [
 		to: #second
 		weight: #third.
 	prim run.
-	tree := prim reconstructMST collect: [ :e | e asTuple ].
+	resultEdges := prim minimumSpanningTreeEdges collect: [ :e | e asTuple ].
 
 	expectedEdges := #( #( 1 2 3 ) #( 2 3 1 ) #( 3 4 2 ) #( 4 5 3 ) ).
-	self assertCollection: tree hasSameElements: expectedEdges.
+	self assertCollection: resultEdges hasSameElements: expectedEdges.
 	self
-		assert: (tree inject: 0 into: [ :sum :edge | sum + edge third ])
+		assert: (resultEdges inject: 0 into: [ :sum :edge | sum + edge third ])
 		equals: 9
 ]

--- a/src/AI-Algorithms-Graph-Tests/AIPrimTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIPrimTest.class.st
@@ -28,7 +28,8 @@ AIPrimTest >> testMinSpanningTreeComplex2 [
 		from: #first
 		to: #second
 		weight: #third.
-	tree := prim run collect: [ :e | e asTuple ].
+	prim run.
+	tree := prim reconstructMST collect: [ :e | e asTuple ].
 	self assert: tree size equals: 11.
 	self
 		assert: (tree inject: 0 into: [ :sum :edge | sum + edge third ])
@@ -47,7 +48,8 @@ AIPrimTest >> testMinimumSpanningTreeComplex [
 		from: #first
 		to: #second
 		weight: #third.
-	tree := prim run collect: [ :e | e asTuple ].
+	prim run.
+	tree := prim reconstructMST collect: [ :e | e asTuple ].
 
 	expectedEdges := #( #( $a $d 1 ) #( $d $e 1 ) #( $d $b 2 )
 	                    #( $e $c 5 ) ).
@@ -69,7 +71,8 @@ AIPrimTest >> testMinimumSpanningTreeSimple [
 		from: #first
 		to: #second
 		weight: #third.
-	tree := prim run collect: [ :e | e asTuple ].
+	prim run.
+	tree := prim reconstructMST collect: [ :e | e asTuple ].
 
 	expectedEdges := #( #( 1 2 3 ) #( 2 3 1 ) #( 3 4 2 ) #( 4 5 3 ) ).
 	self assertCollection: tree hasSameElements: expectedEdges.

--- a/src/AI-Algorithms-Graph/AIPrim.class.st
+++ b/src/AI-Algorithms-Graph/AIPrim.class.st
@@ -6,6 +6,9 @@ For more, see: https://en.wikipedia.org/wiki/Prim%27s_algorithm
 Class {
 	#name : 'AIPrim',
 	#superclass : 'AIGraphAlgorithm',
+	#instVars : [ 
+		'treeEdges' 
+	],
 	#category : 'AI-Algorithms-Graph-Prim',
 	#package : 'AI-Algorithms-Graph',
 	#tag : 'Prim'
@@ -33,6 +36,12 @@ AIPrim >> minNode [
 			lowKey := each distance.
 			lowNode := each ] ].
 	^ lowNode
+]
+
+{ #category : 'accessing' }
+AIPrim >> reconstructMST [
+	
+	^ treeEdges
 ]
 
 { #category : 'configuration' }
@@ -71,6 +80,5 @@ AIPrim >> run [
 			& toNode visited not ifTrue: [
 				toNode previousNode: curNode.
 				toNode distance: curEdge third ] ] ].
-
-	^ treeEdges
+				
 ]

--- a/src/AI-Algorithms-Graph/AIPrim.class.st
+++ b/src/AI-Algorithms-Graph/AIPrim.class.st
@@ -39,7 +39,7 @@ AIPrim >> minNode [
 ]
 
 { #category : 'accessing' }
-AIPrim >> reconstructMST [
+AIPrim >> minimumSpanningTreeEdges [
 	
 	^ treeEdges
 ]
@@ -53,7 +53,7 @@ AIPrim >> nodeClass [
 { #category : 'running' }
 AIPrim >> run [
 
-	| curNode curEdge treeEdges fromNode toNode primEdge |
+	| curNode curEdge fromNode toNode primEdge |
 	nodes do: [ :each | each distance: Float infinity ].
 
 	treeEdges := OrderedCollection new.


### PR DESCRIPTION
Fixes: #28 

**Description:**

This PR fixes the implementation of Prim's algorithm to align with the API conventions.
- Removed explicit return in the `run` method.
- Added `reconstructMST` method to retrieve the edges.
- Updated tests to use `reconstructMST` instead of relying on the return value of `run`.
