### PR TITLE
Implemented Floyd Warshall Algorithm & Added Tests

### DIFF
--- a/src/AI-Algorithms-Graph-Tests/AIFloydWarshallTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIFloydWarshallTest.class.st
@@ -1,0 +1,245 @@
+Class {
+	#name : 'AIFloydWarshallTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'floydWarshall'
+	],
+	#category : 'AI-Algorithms-Graph-Tests-Shortest path',
+	#package : 'AI-Algorithms-Graph-Tests',
+	#tag : 'Shortest path'
+}
+
+{ #category : 'running' }
+AIFloydWarshallTest >> setUp [
+
+	super setUp.
+    floydWarshall := AIFloydWarshall new
+]
+
+{ #category : 'tests' }
+AIFloydWarshallTest >> testAllPairsDistances [
+
+	| graphType graph result |
+	graphType := AICyclicWeightedSimpleFixture new.
+	graph := graphType simpleWeightedGraph2.
+
+	floydWarshall nodes: graph nodes.
+	floydWarshall
+		edges: graph edges
+		from: #first
+		to: #second
+		weight: #third.
+
+	result := floydWarshall runAndGetAllPairsDistances.
+
+	self assert: (result at: { 1. 2 }) equals: 3.
+	self assert: (result at: { 1. 5 }) equals: 8.
+	self assert: (result at: { 3. 5 }) equals: 5
+]
+
+{ #category : 'tests' }
+AIFloydWarshallTest >> testAllPairsPaths [
+
+	| graphType graph result |
+	graphType := AICyclicWeightedSimpleFixture new.
+	graph := graphType simpleWeightedGraph2.
+
+	floydWarshall nodes: graph nodes.
+	floydWarshall
+		edges: graph edges
+		from: #first
+		to: #second
+		weight: #third.
+
+	result := floydWarshall runAndGetAllPairsPaths.
+
+	self assert: (result at: { 1. 2 }) equals: #( 1 2 ).
+	self assert: (result at: { 1. 5 }) equals: #( 1 5 ).
+	self assert: (result at: { 3. 5 }) equals: #( 3 4 5 )
+]
+
+{ #category : 'tests' }
+AIFloydWarshallTest >> testComplexWeightedGraph2 [
+
+	| graphType graph |
+	graphType := AICyclicWeightedComplexFixture new.
+	graph := graphType complexWeightedGraph2.
+
+	floydWarshall nodes: graph nodes.
+	floydWarshall
+		edges: graph edges
+		from: #first
+		to: #second
+		weight: #third.
+
+	floydWarshall run.
+	
+	self assert: (floydWarshall distanceFrom: 0 to: 5) equals: 10.
+
+	self assert: (floydWarshall distanceFrom: 1 to: 5) equals: 6.
+
+	self assert: (floydWarshall distanceFrom: 3 to: 5) equals: 3.
+
+	self
+		assert: (floydWarshall pathFrom: 0 to: 5)
+		equals: #( 0 2 1 3 4 5 ).
+	self assert: (floydWarshall pathFrom: 1 to: 5) equals: #( 1 3 4 5 ).
+	self assert: (floydWarshall pathFrom: 3 to: 5) equals: #( 3 4 5 ).
+
+	self assert: floydWarshall hasNegativeCycle equals: false
+]
+
+{ #category : 'tests' }
+AIFloydWarshallTest >> testHasPathFromTo [
+
+	| graphType graph |
+    graphType := AICyclicWeightedSimpleFixture new.
+    graph := graphType negativeUnconnectedWeightedGraph.
+    
+    floydWarshall nodes: graph nodes.
+    floydWarshall 
+        edges: graph edges
+        from: #first
+        to: #second
+        weight: #third.
+    
+    floydWarshall run.
+    
+    self assert: (floydWarshall hasPathFrom: 0 to: 1).
+    self deny: (floydWarshall hasPathFrom: 0 to: 8).
+    self deny: (floydWarshall hasPathFrom: 0 to: 9).
+]
+
+{ #category : 'tests' }
+AIFloydWarshallTest >> testNegativeUnconnectedWeightedGraph [
+
+	| graphType graph |
+	graphType := AICyclicWeightedSimpleFixture new.
+	graph := graphType negativeUnconnectedWeightedGraph.
+
+	floydWarshall nodes: graph nodes.
+	floydWarshall
+		edges: graph edges
+		from: #first
+		to: #second
+		weight: #third.
+
+	floydWarshall run.
+
+	self assert: (floydWarshall distanceFrom: 0 to: 1) equals: 5.
+	self
+		assert: (floydWarshall distanceFrom: 0 to: 2)
+		equals: Float negativeInfinity.
+	self assert: (floydWarshall distanceFrom: 0 to: 7) equals: -10.
+	self
+		assert: (floydWarshall distanceFrom: 0 to: 8)
+		equals: Float infinity.
+
+	self assert: (floydWarshall pathFrom: 0 to: 1) equals: #( 0 1 ).
+	self assert: (floydWarshall pathFrom: 0 to: 7) equals: #( 0 1 5 6 7 ).
+	self assert: (floydWarshall pathFrom: 0 to: 8) equals: #(  ).
+
+	self assert: floydWarshall hasNegativeCycle equals: true.
+
+	self
+		assert: (floydWarshall distanceFrom: 0 to: 9)
+		equals: Float negativeInfinity.
+	self
+		assert: (floydWarshall pathFrom: 0 to: 9)
+		equals: #( 'Path affected by negative cycle' ).
+
+	self
+		assert: (floydWarshall distanceFrom: 2 to: 3)
+		equals: Float negativeInfinity.
+	self
+		assert: (floydWarshall pathFrom: 2 to: 3)
+		equals: #( 'Path affected by negative cycle' )
+]
+
+{ #category : 'tests' }
+AIFloydWarshallTest >> testNegativeWeightedGraph [
+
+	| graphType graph |
+	graphType := AICyclicWeightedSimpleFixture new.
+	graph := graphType negativeWeightedGraph.
+
+	floydWarshall nodes: graph nodes.
+	floydWarshall
+		edges: graph edges
+		from: #first
+		to: #second
+		weight: #third.
+
+	floydWarshall run.
+
+	self assert: (floydWarshall distanceFrom: 0 to: 8) equals: -20.
+	self
+		assert: (floydWarshall distanceFrom: 0 to: 9)
+		equals: Float negativeInfinity.
+
+	self
+		assert: (floydWarshall pathFrom: 0 to: 8)
+		equals: #( 0 1 5 6 7 8 ).
+	self
+		assert: (floydWarshall pathFrom: 0 to: 9)
+		equals: #( 'Path affected by negative cycle' ).
+
+	self assert: floydWarshall hasNegativeCycle equals: true
+]
+
+{ #category : 'tests' }
+AIFloydWarshallTest >> testSimpleWeightedGraph [
+
+	| graphType graph |
+	graphType := AICyclicWeightedSimpleFixture new.
+	graph := graphType simpleWeightedGraph.
+
+	floydWarshall nodes: graph nodes.
+	floydWarshall
+		edges: graph edges
+		from: #first
+		to: #second
+		weight: #third.
+
+	floydWarshall run.
+
+	self assert: (floydWarshall distanceFrom: 1 to: 5) equals: 3.
+	self assert: (floydWarshall distanceFrom: 2 to: 5) equals: 4.
+	self assert: (floydWarshall distanceFrom: 3 to: 5) equals: 6.
+
+	self assert: (floydWarshall pathFrom: 1 to: 5) equals: #( 1 5 ).
+	self assert: (floydWarshall pathFrom: 2 to: 5) equals: #( 2 4 5 ).
+	self assert: (floydWarshall pathFrom: 3 to: 5) equals: #( 3 4 5 ).
+
+	self assert: floydWarshall hasNegativeCycle equals: false
+]
+
+{ #category : 'tests' }
+AIFloydWarshallTest >> testWeightedDAG [
+
+	| graphType graph |
+	graphType := AIWeightedDAGFixture new.
+	graph := graphType weightedDAG.
+
+	floydWarshall nodes: graph nodes.
+	floydWarshall
+		edges: graph edges
+		from: #first
+		to: #second
+		weight: #third.
+
+	floydWarshall run.
+
+	self assert: (floydWarshall distanceFrom: $A to: $F) equals: 19.
+	self assert: (floydWarshall distanceFrom: $B to: $F) equals: 18.
+	self assert: (floydWarshall distanceFrom: $G to: $F) equals: 17.
+
+	self
+		assert: (floydWarshall pathFrom: $A to: $F)
+		equals: #( $A $B $E $F ).
+	self
+		assert: (floydWarshall pathFrom: $G to: $F)
+		equals: #( $G $D $E $F ).
+
+	self assert: floydWarshall hasNegativeCycle equals: false
+]

--- a/src/AI-Algorithms-Graph-Tests/AIFloydWarshallTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIFloydWarshallTest.class.st
@@ -30,8 +30,9 @@ AIFloydWarshallTest >> testAllPairsDistances [
 		to: #second
 		weight: #third.
 
-	result := floydWarshall runAndGetAllPairsDistances.
-
+	floydWarshall run.
+	result := floydWarshall getAllPairsDistances.
+	
 	self assert: (result at: { 1. 2 }) equals: 3.
 	self assert: (result at: { 1. 5 }) equals: 8.
 	self assert: (result at: { 3. 5 }) equals: 5
@@ -51,8 +52,9 @@ AIFloydWarshallTest >> testAllPairsPaths [
 		to: #second
 		weight: #third.
 
-	result := floydWarshall runAndGetAllPairsPaths.
-
+	floydWarshall run.
+	result := floydWarshall getAllPairsPaths.
+	
 	self assert: (result at: { 1. 2 }) equals: #( 1 2 ).
 	self assert: (result at: { 1. 5 }) equals: #( 1 5 ).
 	self assert: (result at: { 3. 5 }) equals: #( 3 4 5 )

--- a/src/AI-Algorithms-Graph/AIFloydWarshall.class.st
+++ b/src/AI-Algorithms-Graph/AIFloydWarshall.class.st
@@ -1,0 +1,243 @@
+"
+The Floyd-Warshall algorithm is used to find the shortest paths between all pairs of vertices in a weighted graph. This implementation works with both positive and negative edge weights (as long as there are no negative weight cycles) and can detect negative weight cycles in the graph.
+
+The algorithm uses a distance matrix to track the shortest known distances between all pairs of nodes and a next matrix to reconstruct the shortest paths.
+
+Usage example:
+
+fw := AIFloydWarshall new
+    nodes: #(1 2 3);
+    edges: { #(1 2 4). #(2 3 -2). #(3 1 1) }
+        from: #first to: #second weight: #third;
+    run.
+
+fw distanceFrom: 1 to: 3.  ""Returns 2""
+fw pathFrom: 1 to: 3.      ""Returns #(1 2 3)""
+"
+Class {
+	#name : 'AIFloydWarshall',
+	#superclass : 'AIGraphAlgorithm',
+	#instVars : [
+		'distanceMatrix',
+		'nextMatrix',
+		'hasNegativeCycle'
+	],
+	#category : 'AI-Algorithms-Graph-Shortest path',
+	#package : 'AI-Algorithms-Graph',
+	#tag : 'Shortest path'
+}
+
+{ #category : 'configuration' }
+AIFloydWarshall >> distanceFrom: sourceModel to: destinationModel [
+
+| source destination |
+	source := self findNode: sourceModel.
+	destination := self findNode: destinationModel.
+	^ distanceMatrix at: {source. destination}
+]
+
+{ #category : 'accessing' }
+AIFloydWarshall >> distanceMatrix [
+
+	^ distanceMatrix
+]
+
+{ #category : 'configuration' }
+AIFloydWarshall >> edgeClass [
+	
+	^ AIWeightedEdge
+]
+
+{ #category : 'accessing' }
+AIFloydWarshall >> hasNegativeCycle [
+
+	^ hasNegativeCycle
+]
+
+{ #category : 'configuration' }
+AIFloydWarshall >> hasPathFrom: sourceModel to: destinationModel [
+
+	| source destination dist |
+    source := self findNode: sourceModel.
+    destination := self findNode: destinationModel.
+    dist := distanceMatrix at: {source. destination}.
+    ^ dist ~= Float infinity and: [dist ~= Float negativeInfinity]
+]
+
+{ #category : 'initialization' }
+AIFloydWarshall >> initialize [
+
+	super initialize.
+	distanceMatrix := Dictionary new.
+	nextMatrix := Dictionary new.
+	hasNegativeCycle := false.
+]
+
+{ #category : 'accessing' }
+AIFloydWarshall >> nextMatrix [
+
+	^ nextMatrix
+]
+
+{ #category : 'configuration' }
+AIFloydWarshall >> nodeClass [
+
+	^ AIPathDistanceNode
+]
+
+{ #category : 'configuration' }
+AIFloydWarshall >> pathFrom: sourceModel to: destinationModel [
+
+	| source destination path current |
+	source := self findNode: sourceModel.
+	destination := self findNode: destinationModel.
+
+	(distanceMatrix at: {
+			 source.
+			 destination }) = Float infinity ifTrue: [ ^ #(  ) ].
+
+	(distanceMatrix at: {
+			 source.
+			 destination }) = Float negativeInfinity ifTrue: [
+		^ #( 'Path affected by negative cycle' ) ].
+
+	source = destination ifTrue: [ ^ { source model } ].
+
+	path := OrderedCollection new.
+	path add: source model.
+
+	current := source.
+	[ current ~= destination ] whileTrue: [
+		current := nextMatrix at: {
+				           current.
+				           destination }.
+		current ifNil: [
+			^ #( 'Path broken - possible negative cycle effect' ) ].
+		path add: current model ].
+
+	^ path asArray
+]
+
+{ #category : 'actions' }
+AIFloydWarshall >> reset [
+
+	distanceMatrix := Dictionary new.
+	nextMatrix := Dictionary new.
+	hasNegativeCycle := false.
+	self setupMatrices
+]
+
+{ #category : 'running' }
+AIFloydWarshall >> run [
+
+	self reset.
+
+	nodes do: [ :k |
+		nodes do: [ :i |
+			nodes do: [ :j |
+				| currentDist throughK |
+				currentDist := distanceMatrix at: {
+						               i.
+						               j }.
+				((distanceMatrix at: {
+						  i.
+						  k }) ~= Float infinity and: [
+					 (distanceMatrix at: {
+							  k.
+							  j }) ~= Float infinity ]) ifTrue: [
+					throughK := (distanceMatrix at: {
+							             i.
+							             k }) + (distanceMatrix at: {
+							             k.
+							             j }).
+					throughK < currentDist ifTrue: [
+						distanceMatrix
+							at: {
+									i.
+									j }
+							put: throughK.
+						nextMatrix
+							at: {
+									i.
+									j }
+							put: (nextMatrix at: {
+										 i.
+										 k }) ] ] ] ] ].
+
+	nodes do: [ :v |
+		(distanceMatrix at: {
+				 v.
+				 v }) < 0 ifTrue: [ hasNegativeCycle := true ] ].
+
+	hasNegativeCycle ifTrue: [
+		nodes do: [ :k |
+			(distanceMatrix at: {
+					 k.
+					 k }) < 0 ifTrue: [
+				nodes do: [ :i |
+					nodes do: [ :j |
+						((distanceMatrix at: {
+								  i.
+								  k }) ~= Float infinity and: [
+							 (distanceMatrix at: {
+									  k.
+									  j }) ~= Float infinity ]) ifTrue: [
+							distanceMatrix
+								at: {
+										i.
+										j }
+								put: Float negativeInfinity.
+							nextMatrix
+								at: {
+										i.
+										j }
+								put: nil ] ] ] ] ] ]
+]
+
+{ #category : 'running' }
+AIFloydWarshall >> runAndGetAllPairsDistances [
+
+	| result |
+	self run.
+
+	result := Dictionary new.
+	nodes do: [ :source |
+		nodes do: [ :destination |
+			result at: {source model. destination model} put: (distanceMatrix at: {source. destination}).
+		].
+	].
+
+	^ result
+]
+
+{ #category : 'running' }
+AIFloydWarshall >> runAndGetAllPairsPaths [
+
+	| result |
+    self run.
+    result := Dictionary new.
+    nodes do: [ :source |
+        nodes do: [ :destination |
+            result at: {source model. destination model} 
+                put: (self pathFrom: source model to: destination model) ] ].
+    ^ result
+]
+
+{ #category : 'configuration' }
+AIFloydWarshall >> setupMatrices [
+
+	| infinity |
+	infinity := Float infinity.
+
+	nodes do: [ :u |
+		nodes do: [ :v |
+			distanceMatrix at: {u. v} put: (u = v ifTrue: [ 0 ] ifFalse: [ infinity ]).
+			nextMatrix at: {u. v} put: (u = v ifTrue: [ u ] ifFalse: [ nil ]).
+		].
+	].
+
+	edges do: [ :edge |
+		distanceMatrix at: {edge from. edge to} put: edge weight.
+		nextMatrix at: {edge from. edge to} put: edge to.
+	].
+]

--- a/src/AI-Algorithms-Graph/AIFloydWarshall.class.st
+++ b/src/AI-Algorithms-Graph/AIFloydWarshall.class.st
@@ -27,6 +27,22 @@ Class {
 	#tag : 'Shortest path'
 }
 
+{ #category : 'private' }
+AIFloydWarshall >> computeAllPairsShortestPaths [
+
+	nodes do: [ :k |
+        nodes do: [ :i |
+            nodes do: [ :j |
+                | currentDist throughK |
+                currentDist := distanceMatrix at: {i. j}.
+                ((distanceMatrix at: {i. k}) ~= Float infinity and: [
+                   (distanceMatrix at: {k. j}) ~= Float infinity ]) ifTrue: [
+                    throughK := (distanceMatrix at: {i. k}) + (distanceMatrix at: {k. j}).
+                    throughK < currentDist ifTrue: [
+                        distanceMatrix at: {i. j} put: throughK.
+                        nextMatrix at: {i. j} put: (nextMatrix at: {i. k}) ] ] ] ] ]
+]
+
 { #category : 'configuration' }
 AIFloydWarshall >> distanceFrom: sourceModel to: destinationModel [
 
@@ -46,6 +62,56 @@ AIFloydWarshall >> distanceMatrix [
 AIFloydWarshall >> edgeClass [
 	
 	^ AIWeightedEdge
+]
+
+{ #category : 'running' }
+AIFloydWarshall >> getAllPairsDistances [
+
+	| result |
+	
+	result := Dictionary new.
+	nodes do: [ :source |
+		nodes do: [ :destination |
+			result
+				at: {
+						source model.
+						destination model }
+				put: (distanceMatrix at: {
+							 source.
+							 destination }) ] ].
+
+	^ result
+]
+
+{ #category : 'running' }
+AIFloydWarshall >> getAllPairsPaths [
+
+	| result |
+	result := Dictionary new.
+	nodes do: [ :source |
+		nodes do: [ :destination |
+			result
+				at: {
+						source model.
+						destination model }
+				put: (self pathFrom: source model to: destination model) ] ].
+	^ result
+]
+
+{ #category : 'private' }
+AIFloydWarshall >> handleNegativeCycles [
+
+	nodes do: [ :v | (distanceMatrix at: {v. v}) < 0 ifTrue: [ hasNegativeCycle := true ] ].
+    
+    hasNegativeCycle ifTrue: [
+        nodes do: [ :k |
+            (distanceMatrix at: {k. k}) < 0 ifTrue: [
+                nodes do: [ :i |
+                    nodes do: [ :j |
+                        ((distanceMatrix at: {i. k}) ~= Float infinity and: [
+                           (distanceMatrix at: {k. j}) ~= Float infinity ]) ifTrue: [
+                            distanceMatrix at: {i. j} put: Float negativeInfinity.
+                            nextMatrix at: {i. j} put: nil ] ] ] ] ] ]
 ]
 
 { #category : 'accessing' }
@@ -131,96 +197,8 @@ AIFloydWarshall >> reset [
 AIFloydWarshall >> run [
 
 	self reset.
-
-	nodes do: [ :k |
-		nodes do: [ :i |
-			nodes do: [ :j |
-				| currentDist throughK |
-				currentDist := distanceMatrix at: {
-						               i.
-						               j }.
-				((distanceMatrix at: {
-						  i.
-						  k }) ~= Float infinity and: [
-					 (distanceMatrix at: {
-							  k.
-							  j }) ~= Float infinity ]) ifTrue: [
-					throughK := (distanceMatrix at: {
-							             i.
-							             k }) + (distanceMatrix at: {
-							             k.
-							             j }).
-					throughK < currentDist ifTrue: [
-						distanceMatrix
-							at: {
-									i.
-									j }
-							put: throughK.
-						nextMatrix
-							at: {
-									i.
-									j }
-							put: (nextMatrix at: {
-										 i.
-										 k }) ] ] ] ] ].
-
-	nodes do: [ :v |
-		(distanceMatrix at: {
-				 v.
-				 v }) < 0 ifTrue: [ hasNegativeCycle := true ] ].
-
-	hasNegativeCycle ifTrue: [
-		nodes do: [ :k |
-			(distanceMatrix at: {
-					 k.
-					 k }) < 0 ifTrue: [
-				nodes do: [ :i |
-					nodes do: [ :j |
-						((distanceMatrix at: {
-								  i.
-								  k }) ~= Float infinity and: [
-							 (distanceMatrix at: {
-									  k.
-									  j }) ~= Float infinity ]) ifTrue: [
-							distanceMatrix
-								at: {
-										i.
-										j }
-								put: Float negativeInfinity.
-							nextMatrix
-								at: {
-										i.
-										j }
-								put: nil ] ] ] ] ] ]
-]
-
-{ #category : 'running' }
-AIFloydWarshall >> runAndGetAllPairsDistances [
-
-	| result |
-	self run.
-
-	result := Dictionary new.
-	nodes do: [ :source |
-		nodes do: [ :destination |
-			result at: {source model. destination model} put: (distanceMatrix at: {source. destination}).
-		].
-	].
-
-	^ result
-]
-
-{ #category : 'running' }
-AIFloydWarshall >> runAndGetAllPairsPaths [
-
-	| result |
-    self run.
-    result := Dictionary new.
-    nodes do: [ :source |
-        nodes do: [ :destination |
-            result at: {source model. destination model} 
-                put: (self pathFrom: source model to: destination model) ] ].
-    ^ result
+    self computeAllPairsShortestPaths.
+    self handleNegativeCycles.
 ]
 
 { #category : 'configuration' }


### PR DESCRIPTION
Fixes: #44 

### Overview
- Implemented **Floyd-Warshall Algorithm** for all-pairs shortest paths
- Handles both postive and negative edge weights
- Detects negative cycLes in graphs

### Changes 
- Added `AIFloydWarshall` class with implmentation
- Added a comprehensive test suite in `AIFloydWarshallTest`
- Used `Dictionary` for `distanceMatrix` & `nextMatrix`

### Screenshots

Case 1: Graph with no negative weight

![Screenshot from 2025-03-28 01-40-45](https://github.com/user-attachments/assets/6c994b12-dba9-45c6-9a21-e19350e6946b)

Case 2: Graph with negative weight but no negative cycle

![Screenshot from 2025-03-28 01-43-02](https://github.com/user-attachments/assets/08a77d6e-c7cc-4212-815c-e524b9d9d814)

Case 3: Graph with negative cycle 

![Screenshot from 2025-03-28 01-44-30](https://github.com/user-attachments/assets/f330ae2e-3ebb-4589-9885-649dd25ba976)
