### PR TITLE
Recategorized algorithm and tests classes

### DIFF
--- a/src/AI-Algorithms-Graph-Tests/AIAstarTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIAstarTest.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'astar'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Shortest Path Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Shortest Path Tests'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph-Tests/AIBFSTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIBFSTest.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'bfsp'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Shortest Path Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Shortest Path Tests'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph-Tests/AIBellmanFordTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIBellmanFordTest.class.st
@@ -7,9 +7,9 @@ Class {
 	#instVars : [
 		'bellmanFord'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Shortest path',
+	#category : 'AI-Algorithms-Graph-Tests-Shortest Path Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Shortest path'
+	#tag : 'Shortest Path Tests'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph-Tests/AIDFSTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIDFSTest.class.st
@@ -8,9 +8,9 @@ Class {
 	#instVars : [
 		'dfsp'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Shortest Path Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Shortest Path Tests'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph-Tests/AIDijkstraTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIDijkstraTest.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'dijkstra'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Shortest Path Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Shortest Path Tests'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph-Tests/AIDinicTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIDinicTest.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'dinic'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Maximum Flow Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Maximum Flow Tests'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph-Tests/AIEdmondsKarpTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIEdmondsKarpTest.class.st
@@ -4,9 +4,9 @@ Test class for the Edmonds-Karp algorithm
 Class {
 	#name : 'AIEdmondsKarpTest',
 	#superclass : 'TestCase',
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Maximum Flow Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Maximum Flow Tests'
 }
 
 { #category : 'tests' }

--- a/src/AI-Algorithms-Graph-Tests/AIFloydWarshallTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIFloydWarshallTest.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'floydWarshall'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Shortest path',
+	#category : 'AI-Algorithms-Graph-Tests-Shortest Path Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Shortest path'
+	#tag : 'Shortest Path Tests'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph-Tests/AIGraphAlgorithmTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIGraphAlgorithmTest.class.st
@@ -4,9 +4,9 @@ A MalGraphAlgorithmTest is a test class for testing the behavior of MalGraphAlgo
 Class {
 	#name : 'AIGraphAlgorithmTest',
 	#superclass : 'TestCase',
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Basic Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Basic Tests'
 }
 
 { #category : 'tests' }

--- a/src/AI-Algorithms-Graph-Tests/AIGraphMatchingAlgorithmTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIGraphMatchingAlgorithmTest.class.st
@@ -12,9 +12,9 @@ The tests can be grouped as follows:
 Class {
 	#name : 'AIGraphMatchingAlgorithmTest',
 	#superclass : 'TestCase',
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Graph Matching Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Graph Matching Tests'
 }
 
 { #category : 'fixtures' }

--- a/src/AI-Algorithms-Graph-Tests/AIGraphReducerTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIGraphReducerTest.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'graphReducer'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Strongly Connected Components Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Strongly Connected Components Tests'
 }
 
 { #category : 'helpers' }

--- a/src/AI-Algorithms-Graph-Tests/AIHitsTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIHitsTest.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'hits'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Link Analysis Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Link Analysis Tests'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph-Tests/AIKruskalTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIKruskalTest.class.st
@@ -2,24 +2,18 @@ Class {
 	#name : 'AIKruskalTest',
 	#superclass : 'TestCase',
 	#instVars : [
-		'nodes',
 		'kruskal'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Minimum Spanning Tree Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Minimum Spanning Tree Tests'
 }
 
 { #category : 'running' }
 AIKruskalTest >> setUp [
 
 	super setUp.
-	kruskal := AIKruskal new.
-	nodes := OrderedCollection new.
-	nodes add: AIDisjointSetNode new.
-	nodes add: AIDisjointSetNode new.
-	nodes add: AIDisjointSetNode new.
-	nodes add: AIDisjointSetNode new
+	kruskal := AIKruskal new
 ]
 
 { #category : 'tests' }

--- a/src/AI-Algorithms-Graph-Tests/AILongestPathInDAGTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AILongestPathInDAGTest.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'longestPathAlgo'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Shortest Path Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Shortest Path Tests'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph-Tests/AILongestPathInDCGTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AILongestPathInDCGTest.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'longestPathAlgo'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Shortest path',
+	#category : 'AI-Algorithms-Graph-Tests-Shortest Path Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Shortest path'
+	#tag : 'Shortest Path Tests'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph-Tests/AIPrimTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIPrimTest.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'prim'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Minimum Spanning Tree Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Minimum Spanning Tree Tests'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph-Tests/AIShortestPathInDAGTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIShortestPathInDAGTest.class.st
@@ -7,9 +7,9 @@ Class {
 	#instVars : [
 		'shortestPathAlgo'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Shortest Path Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Shortest Path Tests'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph-Tests/AIStableMatchingAlgorithmTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIStableMatchingAlgorithmTest.class.st
@@ -13,9 +13,9 @@ Class {
 		'b2',
 		'b3'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Graph Matching Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Graph Matching Tests'
 }
 
 { #category : 'fixtures' }

--- a/src/AI-Algorithms-Graph-Tests/AIStableMatchingNodeTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIStableMatchingNodeTest.class.st
@@ -9,9 +9,9 @@ Class {
 		'b',
 		'c'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Graph Matching Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Graph Matching Tests'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph-Tests/AITarjanTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AITarjanTest.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'tarjan'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Strongly Connected Components Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Strongly Connected Components Tests'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph-Tests/AITopologicalSortingTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AITopologicalSortingTest.class.st
@@ -7,9 +7,9 @@ Class {
 	#instVars : [
 		'sorter'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Topological Sorting Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Topological Sorting Tests'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph-Tests/AIWeightedHitsTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIWeightedHitsTest.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'hits'
 	],
-	#category : 'AI-Algorithms-Graph-Tests-Tests',
+	#category : 'AI-Algorithms-Graph-Tests-Basic Tests',
 	#package : 'AI-Algorithms-Graph-Tests',
-	#tag : 'Tests'
+	#tag : 'Basic Tests'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph/AIDinic.class.st
+++ b/src/AI-Algorithms-Graph/AIDinic.class.st
@@ -54,9 +54,9 @@ Class {
 		'start',
 		'sink'
 	],
-	#category : 'AI-Algorithms-Graph-Dinic',
+	#category : 'AI-Algorithms-Graph-Maximum Flow',
 	#package : 'AI-Algorithms-Graph',
-	#tag : 'Dinic'
+	#tag : 'Maximum Flow'
 }
 
 { #category : 'configuration' }

--- a/src/AI-Algorithms-Graph/AIHits.class.st
+++ b/src/AI-Algorithms-Graph/AIHits.class.st
@@ -9,9 +9,9 @@ Class {
 	#instVars : [
 		'k'
 	],
-	#category : 'AI-Algorithms-Graph-Hits',
+	#category : 'AI-Algorithms-Graph-Link Analysis',
 	#package : 'AI-Algorithms-Graph',
-	#tag : 'Hits'
+	#tag : 'Link Analysis'
 }
 
 { #category : 'running' }

--- a/src/AI-Algorithms-Graph/AIKruskal.class.st
+++ b/src/AI-Algorithms-Graph/AIKruskal.class.st
@@ -11,9 +11,9 @@ Class {
 	#instVars : [
 		'sortBlock'
 	],
-	#category : 'AI-Algorithms-Graph-Kruskal',
+	#category : 'AI-Algorithms-Graph-Minimum Spanning Tree',
 	#package : 'AI-Algorithms-Graph',
-	#tag : 'Kruskal'
+	#tag : 'Minimum Spanning Tree'
 }
 
 { #category : 'configuration' }

--- a/src/AI-Algorithms-Graph/AIPrim.class.st
+++ b/src/AI-Algorithms-Graph/AIPrim.class.st
@@ -9,9 +9,9 @@ Class {
 	#instVars : [
 		'treeEdges'
 	],
-	#category : 'AI-Algorithms-Graph-Prim',
+	#category : 'AI-Algorithms-Graph-Minimum Spanning Tree',
 	#package : 'AI-Algorithms-Graph',
-	#tag : 'Prim'
+	#tag : 'Minimum Spanning Tree'
 }
 
 { #category : 'configuration' }

--- a/src/AI-Algorithms-Graph/AIWeightedHits.class.st
+++ b/src/AI-Algorithms-Graph/AIWeightedHits.class.st
@@ -10,9 +10,9 @@ Where is detailed how using a weighted graph can improve the results of the Hits
 Class {
 	#name : 'AIWeightedHits',
 	#superclass : 'AIHits',
-	#category : 'AI-Algorithms-Graph-Hits',
+	#category : 'AI-Algorithms-Graph-Link Analysis',
 	#package : 'AI-Algorithms-Graph',
-	#tag : 'Hits'
+	#tag : 'Link Analysis'
 }
 
 { #category : 'running' }


### PR DESCRIPTION
Some algorithm categories were the name of an algorithm, some others the kind of the algorithm.
--> By this PR, the categories are unified for each kind of algorithm, coinciding with book chapter titles.

In the test package, there was a category "shortest path", the other tests were in category "Tests".
--> Now the tests would be grouped by kind of algorithm.

At the same PR time, one unused variable was removed in a test class.

**Just one thing strange to me:** 
When I load my fork, I still detect an empty category "Prim".
In a first try, I removed the category and commited again.
But then I got a strange difference. Thats why I closed my first PR try #57.
Now I do not dare to eliminate the category "Prim".
May be you could have a quick look at that?