### PR TITLE
Add Hopcroft-Karp maximum bipartite matching O(E sqrt V)

### DIFF
--- a/src/AI-Algorithms-Graph-Tests/AIHopcroftKarpTest.class.st
+++ b/src/AI-Algorithms-Graph-Tests/AIHopcroftKarpTest.class.st
@@ -1,0 +1,491 @@
+Class {
+	#name : 'AIHopcroftKarpTest',
+	#superclass : 'TestCase',
+	#category : 'AI-Algorithms-Graph-Tests',
+	#package : 'AI-Algorithms-Graph-Tests'
+}
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testAsymmetricGraph [
+	| algo nodes edges |
+	nodes := #(1 2 $A $B $C $D).
+	edges := #( #(1 $A) #(1 $B) #(2 $C) #(2 $D) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 2.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testBottleneckAndIsolatedEdge [
+	| algo nodes edges |
+	nodes := #(1 2 3 99 $A $B $C $Z).
+	edges := #( #(1 $A) #(2 $A) #(3 $A) #(99 $Z) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 2.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testCompleteBipartite2x2 [
+	| algo nodes edges |
+	nodes := #(1 2 $A $B).
+	edges := #( #(1 $A) #(1 $B) #(2 $A) #(2 $B) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 2.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testCompleteBipartite3x3 [
+	| algo nodes edges |
+	nodes := #(1 2 3 $A $B $C).
+	edges := #( 
+		#(1 $A) #(1 $B) #(1 $C) 
+		#(2 $A) #(2 $B) #(2 $C) 
+		#(3 $A) #(3 $B) #(3 $C) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 3.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testCrownGraph [
+	| algo nodes edges |
+	nodes := #(1 2 3 $A $B $C).
+	edges := #( 
+		#(1 $B) #(1 $C) 
+		#(2 $A) #(2 $C) 
+		#(3 $A) #(3 $B) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 3.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testDenseAsymmetric [
+	| algo nodes edges |
+	nodes := #(1 2 3 4 5 $A $B $C).
+	edges := OrderedCollection new.
+	
+	#(1 2 3 4 5) do: [ :u | 
+		#($A $B $C) do: [ :v | edges add: {u. v} ] ].
+		
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 3.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testDenseMinusOneEdge [
+	| algo nodes edges |
+	nodes := #(1 2 3 $A $B $C).
+	edges := #( 
+		#(1 $A) #(1 $B) #(1 $C) 
+		#(2 $A) #(2 $B) #(2 $C) 
+		#(3 $A) #(3 $B) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 3.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testDisconnectedComponents [
+	| algo nodes edges |
+	nodes := #(1 2 $A $B).
+	edges := #( #(1 $A) #(2 $B) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 2.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testDisjointCompleteGraphs [
+	| algo nodes edges |
+	nodes := #(1 2 3 4 $A $B $C $D).
+	edges := #(
+		#(1 $A) #(1 $B) #(2 $A) #(2 $B) 
+		#(3 $C) #(3 $D) #(4 $C) #(4 $D) 
+	).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 4.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testEmptyGraph [
+	| algo |
+	algo := AIHopcroftKarp new.
+	algo nodes: #().
+	algo edges: #() from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 0.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testEvenCycle [
+	| algo nodes edges |
+	nodes := #(1 2 3 $A $B $C).
+	edges := #( #(1 $A) #(1 $B) #(2 $B) #(2 $C) #(3 $C) #(3 $A) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 3.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testGreedyTrap [
+	| algo nodes edges |
+	nodes := #(1 2 3 4 $A $B $C $D).
+	edges := #( 
+		#(1 $A) #(1 $D) 
+		#(2 $B) #(2 $A) 
+		#(3 $C) #(3 $B) 
+		#(4 $A) #(4 $B) #(4 $C) ).
+		
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 4.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testHallsViolationBottleneck [
+	| algo nodes edges |
+	nodes := #(1 2 3 4 $A $B).
+	edges := #( #(1 $A) #(1 $B) #(2 $A) #(2 $B) #(3 $A) #(3 $B) #(4 $A) #(4 $B) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 2.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testIndependentSubgraphs [
+	| algo nodes edges |
+	nodes := #(1 2 3 $A $B $C $D $E).
+	edges := #( 
+		#(1 $A) #(1 $B) #(2 $A) #(2 $B)  
+		#(3 $C) #(3 $D) #(3 $E)          
+	).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 3.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testInverseStarGraph [
+	| algo nodes edges |
+	nodes := #(1 2 3 4 5 $A).
+	edges := #( #(1 $A) #(2 $A) #(3 $A) #(4 $A) #(5 $A) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 1.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testIsolatedNodes [
+	| algo nodes edges |
+	nodes := #(1 2 3 $A $B $C).
+	edges := #( #(1 $A) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 1.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testLargeEvenCycle [
+	| algo nodes edges |
+	nodes := (1 to: 10).
+	edges := OrderedCollection new.
+	
+	1 to: 5 do: [ :i | 
+		| u v1 v2 |
+		u := i.
+		v1 := i + 5.
+		v2 := (i \\ 5) + 1 + 5.
+		edges add: {u . v1}.
+		edges add: {u . v2} ].
+		
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 5.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testLargeSparseMatching [
+	| algo nodes edges |
+	nodes := (1 to: 1000) asOrderedCollection.
+	edges := OrderedCollection new.
+	
+	1 to: 500 do: [ :i | edges add: {i . i + 500} ].
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 500.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testMassiveStarGraph [
+	| algo nodes edges |
+	nodes := (1 to: 1001) asOrderedCollection.
+	edges := OrderedCollection new.
+	
+	2 to: 1001 do: [ :i | edges add: {1 . i} ]. 
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 1.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testMaximumMatching [
+	| algo nodes edges |
+	nodes := #(1 2 3 $A $B $C).
+	edges := #( #(1 $A) #(1 $B) #(2 $A) #(3 $C) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 3.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testMixedObjectTypes [
+	| algo nodes edges |
+	nodes := #(1 'Node2' $C 3.14 'Target1' $Z 42.0).
+	edges := #( 
+		#(1 'Target1') 
+		#('Node2' $Z) 
+		#($C 42.0) 
+		#(3.14 'Target1') ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 3.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testNoEdges [
+	| algo |
+	algo := AIHopcroftKarp new.
+	algo nodes: #(1 2 3 $A $B $C).
+	algo edges: #() from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 0.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testPathGraph [
+	| algo nodes edges |
+	nodes := #(1 2 3 $A $B $C).
+	edges := #( #(1 $A) #(2 $A) #(2 $B) #(3 $B) #(3 $C) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 3.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testPerformanceDenseGraph [
+	| algo nodes edges |
+	nodes := (1 to: 100).
+	edges := OrderedCollection new.
+	
+	1 to: 50 do: [ :u |
+		51 to: 100 do: [ :v |
+			edges add: {u . v} ] ].
+			
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 50.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testReassignmentPath [
+	| algo nodes edges |
+	nodes := #(1 2 $A $B).
+	edges := #( #(1 $A) #(2 $A) #(2 $B) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 2.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testRegressionDeepAugmentingPaths [
+	| algo nodes edges |
+	nodes := (1 to: 400).
+	edges := OrderedCollection new.
+	
+	1 to: 199 do: [ :i | 
+		edges add: {i . i + 200}.     
+		edges add: {i . i + 201} ].    
+		
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 199.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testRegressionIdentityCheck [
+	| algo nodes edges u1 u2 v1 |
+	u1 := 'DuplicateName' copy.
+	u2 := 'DuplicateName' copy.
+	v1 := 'TargetNode'.
+	
+	nodes := { u1 . u2 . v1 }.
+	edges := { {u1 . v1} . {u2 . v1} }.
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 1.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testStaircaseGraph [
+	| algo nodes edges |
+	nodes := #(1 2 3 4 5 $A $B $C $D $E).
+	edges := #( 
+		#(1 $A) 
+		#(2 $A) #(2 $B) 
+		#(3 $B) #(3 $C) 
+		#(4 $C) #(4 $D) 
+		#(5 $D) #(5 $E) ).
+		
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 5.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testStarGraph [
+	| algo nodes edges |
+	nodes := #(1 $A $B $C $D $E).
+	edges := #( #(1 $A) #(1 $B) #(1 $C) #(1 $D) #(1 $E) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 1.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testStringNodes [
+	| algo nodes edges |
+	nodes := #('Alice' 'Bob' 'Charlie' 'Math' 'Physics' 'Biology').
+	edges := #( 
+		#('Alice' 'Math') 
+		#('Bob' 'Physics') 
+		#('Charlie' 'Biology') 
+		#('Alice' 'Physics') ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 3.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testTreeStructure [
+	| algo nodes edges |
+	nodes := #(1 2 3 4 $A $B $C $D).
+	edges := #( #(1 $A) #(1 $B) #(1 $C) #(2 $D) #(3 $D) #(4 $D) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 2.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testUniquePerfectMatching [
+	| algo nodes edges |
+	nodes := #(1 2 3 $A $B $C).
+	edges := #( 
+		#(1 $A) 
+		#(2 $A) #(2 $B) 
+		#(3 $A) #(3 $B) #(3 $C) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 3.
+]
+
+{ #category : 'tests' }
+AIHopcroftKarpTest >> testWGraph [
+	| algo nodes edges |
+	nodes := #(1 2 3 $A $B $C $D).
+	edges := #( #(1 $A) #(1 $B) #(2 $B) #(2 $C) #(3 $C) #(3 $D) ).
+	
+	algo := AIHopcroftKarp new.
+	algo nodes: nodes.
+	algo edges: edges from: [ :e | e first ] to: [ :e | e second ].
+	
+	self assert: algo run equals: 3.
+]

--- a/src/AI-Algorithms-Graph/AIHopcroftKarp.class.st
+++ b/src/AI-Algorithms-Graph/AIHopcroftKarp.class.st
@@ -1,0 +1,106 @@
+Class {
+	#name : 'AIHopcroftKarp',
+	#superclass : 'AIGraphAlgorithm',
+	#instVars : [
+		'pairU',
+		'pairV',
+		'dist',
+		'queue',
+		'nilNode',
+		'adjacencyList',
+		'infinity'
+	],
+	#category : 'AI-Algorithms-Graph',
+	#package : 'AI-Algorithms-Graph'
+}
+
+{ #category : 'as yet unclassified' }
+AIHopcroftKarp >> adjacentNodesOf: u [
+	^ adjacencyList at: u ifAbsent: [ #() ]
+]
+
+{ #category : 'backtracking' }
+AIHopcroftKarp >> bfs [
+	queue removeAll.
+	
+	pairU keysDo: [ :u |
+		(pairU at: u) == nilNode
+			ifTrue: [ dist at: u put: 0. queue addLast: u ]
+			ifFalse: [ dist at: u put: infinity ] ].
+			
+	dist at: nilNode put: infinity.
+	
+	[ queue isNotEmpty ] whileTrue: [ 
+		| u |
+		u := queue removeFirst.
+		(dist at: u) < (dist at: nilNode) ifTrue: [ 
+			(adjacencyList at: u ifAbsent: [ #() ]) do: [ :v |
+				| pairedU |
+				pairedU := pairV at: v ifAbsent: [ nilNode ].
+				(dist at: pairedU) == infinity ifTrue: [ 
+					dist at: pairedU put: (dist at: u) + 1.
+					pairedU == nilNode ifFalse: [ queue addLast: pairedU ] ] ] ] ].
+			
+	^ (dist at: nilNode) ~= infinity
+]
+
+{ #category : 'backtracking' }
+AIHopcroftKarp >> dfs: u [
+	u == nilNode ifFalse: [ 
+		(adjacencyList at: u ifAbsent: [ #() ]) do: [ :v |
+			| pairedU |
+			pairedU := pairV at: v ifAbsent: [ nilNode ].
+			(dist at: pairedU) == ((dist at: u) + 1) ifTrue: [ 
+				(self dfs: pairedU) ifTrue: [ 
+					pairV at: v put: u.
+					pairU at: u put: v.
+					^ true ] ] ].
+		
+		dist at: u put: infinity.
+		^ false ].
+	^ true
+]
+
+{ #category : 'as yet unclassified' }
+AIHopcroftKarp >> findNeighborsOf: aNode [
+	(aNode respondsTo: #adjacentNodes) ifTrue: [ ^ aNode adjacentNodes ].
+	(aNode respondsTo: #outgoingNodes) ifTrue: [ ^ aNode outgoingNodes ].
+	(aNode respondsTo: #outgoingEdges) ifTrue: [ 
+		^ aNode outgoingEdges collect: [ :e | 
+			(e respondsTo: #to) ifTrue: [ e to ] ifFalse: [ e target ] ] ].
+	^ #()
+]
+
+{ #category : 'initialization' }
+AIHopcroftKarp >> initializeVariables [
+	pairU := IdentityDictionary new.
+	pairV := IdentityDictionary new.
+	dist := IdentityDictionary new.
+	adjacencyList := IdentityDictionary new.
+	queue := OrderedCollection new.
+	nilNode := Object new.
+	infinity := SmallInteger maxVal. 
+	
+	self nodes do: [ :node | 
+		| neighbors |
+		neighbors := self findNeighborsOf: node.
+		adjacencyList at: node put: neighbors.
+		
+		neighbors isNotEmpty ifTrue: [ 
+			pairU at: node put: nilNode.
+			neighbors do: [ :v | pairV at: v put: nilNode ] ] ].
+]
+
+{ #category : 'running' }
+AIHopcroftKarp >> run [
+	| matchingSize |
+	self initializeVariables.
+	matchingSize := 0.
+	
+	[ self bfs ] whileTrue: [
+		pairU keysDo: [ :u |
+			(pairU at: u) == nilNode ifTrue: [
+				(self dfs: u) ifTrue: [ matchingSize := matchingSize + 1 ] ] ] ].
+		
+	^ matchingSize
+]


### PR DESCRIPTION
This PR introduces the **Hopcroft-Karp algorithm** to find the maximum matching in a bipartite graph. 

It executes in strict $O(E \sqrt{V})$ time, making it significantly faster than standard Ford-Fulkerson or Edmonds-Karp approaches for bipartite structures.

### Key Implementation Details:
* **Strict Separation:** Dynamically partitions the bipartite graph into $U$ and $V$ sets directly from the provided edges, bypassing standard wrapper limits.
* **Optimized Queues:** BFS strict bounds use `SmallInteger maxVal` instead of float infinity to guarantee lightning-fast `==` identity checks.
* **Robust Augmenting Paths:** DFS uses `IdentityDictionary` lookups to trace exactly the shortest augmenting paths without `nilNode` queue leakage.

### Testing
Added `AIHopcroftKarpTest` with **33 comprehensive unit tests**, including:
- Empty graphs and disconnected components.
- Complete bipartite matrices.
- Cycles, trees, and long path structures.
- Regressions for deep augmenting paths and strict object identity checks.

And all tests is **green**!

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/089bf82c-dd0e-47d4-9b6a-8c0f7de2a801" />


Ready for review! 