### PR TITLE
Refactor: Replace manual #respondsTo: checks with polymorphic dispatch

### DIFF
--- a/src/AI-Algorithms-Graph/AIHopcroftKarp.class.st
+++ b/src/AI-Algorithms-Graph/AIHopcroftKarp.class.st
@@ -69,12 +69,7 @@ AIHopcroftKarp >> dfs: u [
 
 { #category : 'private' }
 AIHopcroftKarp >> findNeighborsOf: aNode [
-	(aNode respondsTo: #adjacentNodes) ifTrue: [ ^ aNode adjacentNodes ].
-	(aNode respondsTo: #outgoingNodes) ifTrue: [ ^ aNode outgoingNodes ].
-	(aNode respondsTo: #outgoingEdges) ifTrue: [ 
-		^ aNode outgoingEdges collect: [ :e | 
-			(e respondsTo: #to) ifTrue: [ e to ] ifFalse: [ e target ] ] ].
-	^ #()
+    ^ aNode adjacentNodes
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
Following the discussion in #67, this PR refactors the `findNeighborsOf:` method in the `AIHopcroftKarp` class.